### PR TITLE
Support Windows and npm link install scenario

### DIFF
--- a/install-npm.js
+++ b/install-npm.js
@@ -4,8 +4,14 @@ var npmModule
   , path = require('path')
   ;
 
-if (process.env['npm_execpath'] && process.env['npm_execpath'].match(/\/node_modules\/npm\/bin\/npm-cli\.js$/)) {
-  npmModule = require(path.resolve(process.env['npm_execpath'], '..', '..'));
+if (process.env['npm_execpath']) {
+  if (process.platform === 'win32') {
+    process.env['npm_execpath'] = process.env['npm_execpath'].replace(/\\/g, '/');
+  }
+
+  if (process.env['npm_execpath'].match(/\/node_modules\/npm\/bin\/npm-cli\.js$/)) {
+    npmModule = require(path.resolve(process.env['npm_execpath'], '..', '..'));
+  }
 }
 
 // if no npm module found, don't expose any function

--- a/install-npm.js
+++ b/install-npm.js
@@ -10,7 +10,7 @@ if (process.env['npm_execpath']) {
   var execPath = process.env['npm_execpath'];
   var expectedPath = path.join('bin', 'npm-cli.js');
 
-  if (execPath.slice(-expectedPath.length) === expectedPath) {
+  if (execPath.slice(-1 * expectedPath.length) === expectedPath) {
     npmBin = path.resolve(execPath);
   }
 }

--- a/install-yarn.js
+++ b/install-yarn.js
@@ -1,18 +1,17 @@
 // do it inline in sync way
 // to make it work in non-npm environment
-var yarnModule
+var yarnBin
   , executioner
   , path = require('path')
   , node = process.argv[0]
   ;
 
-if (process.env['npm_execpath']) {
-  if (process.platform === 'win32') {
-    process.env['npm_execpath'] = process.env['npm_execpath'].replace(/\\/g, '/');
-  }
+if (process.env['npm_execpath'] && process.env['npm_execpath'].match(/node_modules[\/\\]yarn[\/\\]bin[\/\\]yarn\.js$/)) {
+  var execPath = process.env['npm_execpath'];
+  var expectedPath = path.join('yarn', 'bin', 'yarn.js');
 
-  if (process.env['npm_execpath'].match(/node_modules\/yarn\/bin\/yarn\.js$/)) {
-    yarnModule = path.resolve(process.env['npm_execpath'], '..', '..', 'lib', 'cli');
+  if (execPath.slice(-expectedPath.length) === expectedPath) {
+    yarnBin = path.resolve(execPath, '..', '..', 'lib', 'cli');
   }
 }
 
@@ -20,26 +19,25 @@ if (process.env['npm_execpath']) {
 // to allow upstream modules find alternatives
 module.exports = null;
 
-if (yarnModule) {
-
+if (yarnBin) {
   executioner = require('executioner');
 
   module.exports = function(packages, extra, done) {
-
     var options = {
       node    : node,
-      yarn    : yarnModule,
+      yarn    : yarnBin,
       // escape package names@versions
       packages: packages.map((pkg) => '"' + pkg + '"').join(' ')
     };
 
-    executioner('${node} ${yarn} add --peer --no-lockfile ${packages}', options, function(error, result) {
+    executioner('"${node}" "${yarn}" add --peer --no-lockfile ${packages}', options, function(error, result) {
+      console.dir(result);
       if (error) {
         console.error('Unable to install peerDependencies', error);
         process.exit(1);
         return;
       }
-      done();
+      done(result);
     });
 
     // Looks like yarn shows last line from the output of sub-scripts

--- a/install-yarn.js
+++ b/install-yarn.js
@@ -6,8 +6,14 @@ var yarnModule
   , node = process.argv[0]
   ;
 
-if (process.env['npm_execpath'] && process.env['npm_execpath'].match(/node_modules\/yarn\/bin\/yarn\.js$/)) {
-  yarnModule = path.resolve(process.env['npm_execpath'], '..', '..', 'lib', 'cli');
+if (process.env['npm_execpath']) {
+  if (process.platform === 'win32') {
+    process.env['npm_execpath'] = process.env['npm_execpath'].replace(/\\/g, '/');
+  }
+
+  if (process.env['npm_execpath'].match(/node_modules\/yarn\/bin\/yarn\.js$/)) {
+    yarnModule = path.resolve(process.env['npm_execpath'], '..', '..', 'lib', 'cli');
+  }
 }
 
 // if no yarn module found, don't expose any function

--- a/install-yarn.js
+++ b/install-yarn.js
@@ -31,7 +31,6 @@ if (yarnBin) {
     };
 
     executioner('"${node}" "${yarn}" add --peer --no-lockfile ${packages}', options, function(error, result) {
-      console.dir(result);
       if (error) {
         console.error('Unable to install peerDependencies', error);
         process.exit(1);

--- a/install-yarn.js
+++ b/install-yarn.js
@@ -10,7 +10,7 @@ if (process.env['npm_execpath'] && process.env['npm_execpath'].match(/node_modul
   var execPath = process.env['npm_execpath'];
   var expectedPath = path.join('yarn', 'bin', 'yarn.js');
 
-  if (execPath.slice(-expectedPath.length) === expectedPath) {
+  if (execPath.slice(-1 * expectedPath.length) === expectedPath) {
     yarnBin = path.resolve(execPath, '..', '..', 'lib', 'cli');
   }
 }

--- a/install.js
+++ b/install.js
@@ -16,11 +16,15 @@ var fs          = require('fs')
   }
   ;
 
+console.dir(__dirname);
+
 // in npm@3+ preinstall happens in `node_modules/.staging` folder
 // so if we ended up in `node_modules/` jump one level up
 if (path.basename(rootPath) === 'node_modules') {
   rootPath = path.resolve(rootPath, '..');
 }
+
+console.dir(rootPath);
 
 installPeerDeps();
 
@@ -56,6 +60,8 @@ function installPeerDeps() {
       installYarn(peerDeps, peerInstallOptions, installDone.bind(null, 'yarn'));
     } else if (installNpm) {
       installNpm(peerDeps, peerInstallOptions, installDone.bind(null, 'npm'));
+    } else {
+      console.error('Did not find a viable package manager to install dependencies with.');
     }
   });
 }

--- a/install.js
+++ b/install.js
@@ -3,7 +3,7 @@ var fs          = require('fs')
   , installNpm  = require('./install-npm.js')
   , installYarn = require('./install-yarn.js')
 
-  , rootPath    = path.resolve(__dirname, '..', '..')
+  , rootPath    = path.resolve(process.cwd(), '..', '..')
 
   , envLabel    = 'skip_install_peers_as_dev'
 
@@ -15,8 +15,6 @@ var fs          = require('fs')
     'save-prod': false
   }
   ;
-
-console.dir(__dirname);
 
 // in npm@3+ preinstall happens in `node_modules/.staging` folder
 // so if we ended up in `node_modules/` jump one level up

--- a/install.js
+++ b/install.js
@@ -3,7 +3,7 @@ var fs          = require('fs')
   , installNpm  = require('./install-npm.js')
   , installYarn = require('./install-yarn.js')
 
-  , rootPath    = path.resolve(process.cwd(), '..', '..')
+  , rootPath    = process.env.INIT_CWD || path.resolve('../..', process.cwd())
 
   , envLabel    = 'skip_install_peers_as_dev'
 

--- a/install.js
+++ b/install.js
@@ -3,7 +3,7 @@ var fs          = require('fs')
   , installNpm  = require('./install-npm.js')
   , installYarn = require('./install-yarn.js')
 
-  , rootPath    = process.env.INIT_CWD || path.resolve('../..', process.cwd())
+  , rootPath    = process.env.INIT_CWD || path.resolve(process.cwd(), '..', '..')
 
   , envLabel    = 'skip_install_peers_as_dev'
 

--- a/install.js
+++ b/install.js
@@ -22,8 +22,6 @@ if (path.basename(rootPath) === 'node_modules') {
   rootPath = path.resolve(rootPath, '..');
 }
 
-console.dir(rootPath);
-
 installPeerDeps();
 
 // --- Subroutines

--- a/install.js
+++ b/install.js
@@ -62,12 +62,13 @@ function installPeerDeps() {
   });
 }
 
-function installDone(tool) {
-
+function installDone(tool, result) {
   // cleanup env
   process.env[envLabel] = '';
 
   console.log('Installed peerDependencies as devDependencies via ' + tool + '.');
+
+  console.log(result);
 }
 
 function getPeerDeps(config) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "install-peers",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Automatically installs project's peerDependencies (as devDependencies)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I would like to use this package to help manage the pain point of installing `react-dom` manually. This package would seem to be the perfect solution. However, I found (after several hours investigation) that it does not seem to support Windows, because the matcher regex used to find npm and/or yarn only matches on Unix-style paths.

In testing/reproducing this, I also found that it does not work when used as an `npm link` package - because `__dirname` used in `install.js` points to the physical path on disk of the non-symlinked package directory, not the path that `install-peers` occupies under the `node_modules` of the package (e.g. `/code/install-peers` rather than `/code/install-peers-test/node_modules/install-peers` which is a symlink to `/code/install-peers`).

I am using [these configurations](https://gist.github.com/ayan4m1/e8261cb6a33a1436f8b9d0f4e68e8753) to test peer dependency installation.

Example output using 1.0.2 on Windows (`react-dom` is not present in `node_modules` afterward):

> $ npm install
> 
> > install-peers@1.0.2 postinstall C:\code\install-peers-test\node_modules\install-peers
> > node install.js
> 
> npm WARN install-peers-test@0.1.0 requires a peer of react-dom@^16.6.0 but none is installed. You must install peer dependencies yourself.
> npm WARN install-peers-test@0.1.0 No description
> npm WARN install-peers-test@0.1.0 No repository field.
> 
> added 10 packages from 4 contributors and audited 16 packages in 4.096s
> found 0 vulnerabilities

Example output using my branch on Windows (`react-dom` is present in `node_modules` afterward):

> $ npm install
> 
> > install-peers@1.0.2 postinstall C:\code\install-peers-test\node_modules\install-peers
> > node install.js
> 
> npm WARN install-peers-test@0.1.0 No description
> npm WARN install-peers-test@0.1.0 No repository field.
> 
> + react-dom@16.6.0
> added 1 package and audited 16 packages in 51.138s
> found 0 vulnerabilities
> 
> Installed peerDependencies as devDependencies via npm.
> npm notice created a lockfile as package-lock.json. You should commit this file.
> npm WARN install-peers-test@0.1.0 requires a peer of react-dom@^16.6.0 but none is installed. You must install peer dependencies yourself.
> npm WARN install-peers-test@0.1.0 No description
> npm WARN install-peers-test@0.1.0 No repository field.
> 
> added 10 packages from 4 contributors and audited 16 packages in 70.714s
> found 0 vulnerabilities

I have prepared this pull request with four changes:

* Added code to `install-yarn.js` and `install-npm.js` that "flips" the path separators if the platform is win32, allowing the regex matcher to work on Windows
* `rootPath` will be set to `process.env.INIT_CWD` if it is present (npm 5+), which allows the package to be used in `npm link` scenarios on *nix - this environment variable avoids the need to use relative pathing to find the package root
* Changed `__dirname` to `process.cwd()` in `rootPath` fallback initialization, which allows the package to be used in `npm link` scenarios
* Added a `console.error` message if neither `yarn` nor `npm` are found on the system, thus alerting the user to the reason no action was taken during execution

There is one case, where the user is on *nix and does not have npm 5+, where the `npm link` scenario will fail. However, this has always been the case. Unfortunately, `process.cwd()` `process.env.PWD` and `__dirname` are all the "incorrect" value in this environment, and `process.env.INIT_CWD` is not available.

My testing on Windows was done using Windows 10, Node 10.12.0. I regression-tested the package using it in both `npm link` and non-link scenarios on CentOS 7, Node 6.14.4 (npm 3) and 10.13.0 (npm 6).

Please let me know your thoughts and feedback.